### PR TITLE
Initialize data in video buffer

### DIFF
--- a/src/SmackerDecoder.cpp
+++ b/src/SmackerDecoder.cpp
@@ -321,6 +321,7 @@ bool SmackerDecoder::Open(SDL_RWops *rwops)
 	nFrames = file.ReadUint32LE();
 
 	picture = new uint8_t[frameWidth * frameHeight];
+	memset(picture, 0, frameWidth * frameHeight);
 
 	int32_t frameRate = file.ReadUint32LE();
 


### PR DESCRIPTION
Given that the library wasn't already doing this, I suppose the Smacker format probably doesn't explicitly define a default background color index so zero is probably as good as anything. At the very least, this resolves an issue with the Blizzard logo video.